### PR TITLE
PLATFORM-1963: keep oauthlib version below 0.7.0

### DIFF
--- a/pokitdok/__init__.py
+++ b/pokitdok/__init__.py
@@ -9,10 +9,10 @@
 from __future__ import absolute_import
 
 __title__ = 'pokitdok'
-__version__ = '1.0'
+__version__ = '1.1'
 __author__ = 'PokitDok, Inc.'
 __license__ = 'MIT'
-__copyright__ = 'Copyright 2014 PokitDok, Inc.'
+__copyright__ = 'Copyright 2014-2015 PokitDok, Inc.'
 
 
 import pokitdok.api

--- a/pokitdok/api/client.py
+++ b/pokitdok/api/client.py
@@ -129,6 +129,15 @@ class PokitDokClient(object):
         cash_prices_url = "{0}/prices/cash".format(self.url_base)
         return self.api_client.get(cash_prices_url, params=kwargs, headers=self.base_headers).json()
 
+    def ccd(self, ccd_request):
+        """
+            Submit a continuity of care document (CCD) request
+
+            :param ccd_request: dictionary representing a CCD request
+        """
+        ccd_url = "{0}/ccd/".format(self.url_base)
+        return self.api_client.post(ccd_url, data=json.dumps(ccd_request), headers=self.json_headers).json()
+
     def claims(self, claims_request):
         """
             Submit a claims request

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,12 @@ from setuptools import setup
 
 setup(
     name="pokitdok",
-    version="1.0",
+    version="1.1",
     license="MIT",
     author="PokitDok, Inc.",
     author_email="platform@pokitdok.com",
     url="https://platform.pokitdok.com",
-    download_url='https://github.com/pokitdok/pokitdok-python/tarball/1.0',
+    download_url='https://github.com/pokitdok/pokitdok-python/tarball/1.1',
     description="PokitDok Platform API Client",
     long_description=__doc__,
     packages=["pokitdok", "pokitdok.api"],
@@ -35,7 +35,7 @@ setup(
     include_package_data=True,
     platforms="any",
     install_requires=[
-        "requests>=2.3.0", "requests-oauthlib==0.4.1"
+        "requests>=2.3.0", "oauthlib<0.7.0", "requests-oauthlib==0.4.1"
     ],
     tests_require=[
         "vcrpy==1.0.2"


### PR DESCRIPTION
keep the oauthlib version below 0.7.0 to avoid Warnings when fetching an access token for scope protected APIs.
There's an open issue about this for requests_oauthlib: https://github.com/requests/requests-oauthlib/issues/157