### PR TITLE
PLATFORM-2528: Update python client library to support enrollment snapshots

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -240,6 +240,86 @@ Quick start
     #convert existing claims in a X12 837 file to claims request JSON.  ICD-9 codes are converted to ICD-10
     pd.claims_convert('/path/to/my_claims.837')
 
+    #Use the specified X12 834 file as the current membership enrollment snapshot for a trading partner
+    pd.enrollment_snapshot('MOCKPAYER', '/path/to/current_membership_enrollment.834')
+
+    #Submit an enrollment request to establish benefits for a new employee
+    pd.enrollment({
+        "action": "Change",
+        "dependents": [],
+        "master_policy_number": "ABCD012354",
+        "payer": {
+            "tax_id": "654456654"
+        },
+        "purpose": "Original",
+        "sponsor": {
+            "tax_id": "999888777"
+        },
+        "subscriber": {
+            "address": {
+                "city": "CAMP HILL",
+                "county": "CUMBERLAND",
+                "line": "100 MARKET ST",
+                "line2": "APT 3G",
+                "postal_code": "17011",
+                "state": "PA"
+            },
+            "benefit_status": "Active",
+            "benefits": [
+                {
+                    "begin_date": " 2015-01-01",
+                    "benefit_type": "Health",
+                    "coordination_of_benefits": [
+                        {
+                            "group_or_policy_number": "890111",
+                            "payer_responsibility": "Primary",
+                            "status": "Unknown"
+                        }
+                    ],
+                    "late_enrollment": False,
+                    "maintenance_type": "Addition"
+                },
+                {
+                    "begin_date": "2015-01-01",
+                    "benefit_type": "Dental",
+                    "late_enrollment": False,
+                    "maintenance_type": "Addition"
+                },
+                {
+                    "begin_date": "2015-01-01",
+                    "benefit_type": "Vision",
+                    "late_enrollment": False,
+                    "maintenance_type": "Addition"
+                }
+            ],
+            "birth_date": "1940-01-01",
+            "contacts": [
+                {
+                    "communication_number2": "7172341240",
+                    "communication_type2": "Work Phone Number",
+                    "primary_communication_number": "7172343334",
+                    "primary_communication_type": "Home Phone Number"
+                }
+            ],
+            "eligibility_begin_date": "2014-01-01",
+            "employment_status": "Full-time",
+            "first_name": "JOHN",
+            "gender": "Male",
+            "group_or_policy_number": "123456001",
+            "handicapped": False,
+            "last_name": "DOE",
+            "maintenance_reason": "Active",
+            "maintenance_type": "Addition",
+            "member_id": "123456789",
+            "middle_name": "P",
+            "relationship": "Self",
+            "ssn": "123456789",
+            "subscriber_number": "123456789",
+            "substance_abuse": False,
+            "tobacco_use": False
+        },
+        "trading_partner_id": "MOCKPAYER",
+    })
 
 
 See the documentation_ for detailed information on all of the PokitDok Platform APIs.

--- a/pokitdok/__init__.py
+++ b/pokitdok/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014, All Rights Reserved, PokitDok, Inc.
+# Copyright (C) 2014-2015, All Rights Reserved, PokitDok, Inc.
 # https://www.pokitdok.com
 #
 # Please see the License.txt file for more information.
@@ -9,7 +9,7 @@
 from __future__ import absolute_import
 
 __title__ = 'pokitdok'
-__version__ = '1.2'
+__version__ = '1.3'
 __author__ = 'PokitDok, Inc.'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2014-2015 PokitDok, Inc.'

--- a/pokitdok/api/client.py
+++ b/pokitdok/api/client.py
@@ -218,6 +218,45 @@ class PokitDokClient(object):
         return self.api_client.post(enrollment_url, data=json.dumps(enrollment_request),
                                     headers=self.json_headers).json()
 
+    def enrollment_snapshot(self, trading_partner_id, x12_file):
+        """
+            Submit a X12 834 file to the platform to establish the enrollment information within it
+            as the current membership enrollment snapshot for a trading partner
+
+            :param trading_partner_id: the trading partner associated with the enrollment snapshot
+            :param x12_file: the path to a X12 834 file that contains the current membership enrollment information
+        """
+        enrollment_snapshot_url = "{0}/enrollment/snapshot".format(self.url_base)
+        return self.api_client.post(enrollment_snapshot_url,
+                                    headers=self.base_headers,
+                                    data={'trading_partner_id': trading_partner_id},
+                                    files={'file': (os.path.split(x12_file)[-1], open(x12_file, 'rb'),
+                                                    'application/EDI-X12')}).json()
+
+    def enrollment_snapshots(self, snapshot_id=None, **kwargs):
+        """
+            List enrollment snapshots that are stored for the client application
+        """
+        enrollment_snapshots_url = "{0}/enrollment/snapshot{1}".format(self.url_base,
+                                                                       '/{}'.format(snapshot_id) if snapshot_id else '')
+        request_args = {}
+        if snapshot_id is None:
+            request_args.update(kwargs)
+
+        return self.api_client.get(enrollment_snapshots_url, params=request_args, headers=self.base_headers).json()
+
+    def enrollment_snapshot_data(self, snapshot_id, **kwargs):
+        """
+            List enrollment request objects that make up the specified enrollment snapshot
+
+            :param snapshot_id: the enrollment snapshot id for the enrollment data
+        """
+        enrollment_snapshot_data_url = "{0}/enrollment/snapshot/{1}/data".format(self.url_base, snapshot_id)
+        request_args = {}
+        request_args.update(kwargs)
+
+        return self.api_client.get(enrollment_snapshot_data_url, params=request_args, headers=self.base_headers).json()
+
     def files(self, trading_partner_id, x12_file):
         """
             Submit a raw X12 file to the platform for processing

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,12 @@ from setuptools import setup
 
 setup(
     name="pokitdok",
-    version="1.2",
+    version="1.3",
     license="MIT",
     author="PokitDok, Inc.",
     author_email="platform@pokitdok.com",
     url="https://platform.pokitdok.com",
-    download_url='https://github.com/pokitdok/pokitdok-python/tarball/1.2',
+    download_url='https://github.com/pokitdok/pokitdok-python/tarball/1.3',
     description="PokitDok Platform API Client",
     long_description=__doc__,
     packages=["pokitdok", "pokitdok.api"],
@@ -42,7 +42,7 @@ setup(
     ],
     test_suite='nose.collector',
     keywords=['health', 'api', 'pokitdok', 'X12', 'eligibility', 'claims', 'providers', 'prices', 'healthcare',
-              'referrals', 'authorizations', 'insurance', 'plans'],
+              'referrals', 'authorizations', 'insurance', 'plans', 'benefits', 'enrollment'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",


### PR DESCRIPTION
These changes update the PokitDok Python client library to add support for enrollment snapshot functionality.   Enrollment snapshots allow applications using the `enrollment` API to establish a current snapshot of membership enrollment information for a group/trading partner combination.  This simplifies interactions with trading partners that require full 834 files even when only a few changes are made.