### PR TITLE
PLATFORM-2831: /identity endpoint 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -321,6 +321,70 @@ Quick start
         "trading_partner_id": "MOCKPAYER",
     })
 
+    # create an identity resource
+    pd.create_identity({
+        "prefix": "Mr.",
+        "first_name": "Oscar",
+        "middle_name": "Harold",
+        "last_name": "Whitmire",
+        "suffix": "IV",
+        "birth_date": "2000-05-01",
+        "gender": "male",
+        "email": "oscar@pokitdok.com",
+        "phone": "555-555-5555",
+        "secondary_phone": "333-333-4444",
+        "address": {
+            "address_lines": ["1400 Anyhoo Avenue"],
+            "city": "Springfield",
+            "state": "IL",
+            "zipcode": "90210"
+        },
+        "identifiers": [
+            {
+                "location": [-121.93831, 37.53901],
+                "provider_uuid": "1917f12b-fb6a-4016-93bc-adeb83204c83",
+                "system_uuid": "967d207f-b024-41cc-8cac-89575a1f6fef",
+                "value": "W90100-IG-88"
+
+            }
+        ]
+    })
+
+    # update an identity resource
+    pd.update_identity("881bc095-2068-43cb-9783-cce630364122", {
+        "prefix": "Mr.",
+        "first_name": "Oscar",
+        "middle_name": "Harold",
+        "last_name": "Whitmire",
+        "suffix": "IV",
+        "birth_date": "2000-05-01",
+        "gender": "male",
+        "email": "oscar.whitmire@pokitdok.com",
+        "phone": "555-555-5555",
+        "secondary_phone": "333-333-4444",
+        "address": {
+            "address_lines": ["1400 Anyhoo Avenue"],
+            "city": "Springfield",
+            "state": "IL",
+            "zipcode": "90210"
+        },
+        "identifiers": [
+            {
+                "location": [-121.93831, 37.53901],
+                "provider_uuid": "1917f12b-fb6a-4016-93bc-adeb83204c83",
+                "system_uuid": "967d207f-b024-41cc-8cac-89575a1f6fef",
+                "value": "W90100-IG-88"
+
+            }
+        ]
+    })
+
+    # query for a single identity resource using uuid
+    pd.identity("881bc095-2068-43cb-9783-cce630364122")
+
+    # query for identity resources using fields
+    pd.identity(first_name='Oscar', last_name='Whitmire', gender='male')
+
 
 See the documentation_ for detailed information on all of the PokitDok Platform APIs.
 The Quick Start Guide is also available as an IPython_ notebook_.

--- a/notebooks/PlatformQuickStartDemo.ipynb
+++ b/notebooks/PlatformQuickStartDemo.ipynb
@@ -1,278 +1,444 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:a146e0e0d3ad4d9f2f723dbeed6bfe513f7842c827ab35f462a49a952d4470b0"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Connect and Authenticate"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import pokitdok"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "pd = pokitdok.api.connect('[your client id]', '[your client secret]')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Prices"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "pd.cash_prices(zip_code='32218', cpt_code='87799')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "pd.insurance_prices(zip_code='32218', cpt_code='87799')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Providers"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "pd.providers(npi='1467560003')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "pd.providers(first_name='Jerome', last_name='Aya-Ay')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "pd.providers(organization_name='Qliance')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "pd.providers(zipcode='29307', radius='10mi')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "pd.providers(zipcode='29307', radius='10mi', specialty='RHEUMATOLOGY')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Eligibility"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "pd.eligibility({\n",
-      "    \"member\": {\n",
-      "        \"birth_date\": \"1970-01-01\",\n",
-      "        \"first_name\": \"Jane\",\n",
-      "        \"last_name\": \"Doe\",\n",
-      "        \"id\": \"W000000000\"\n",
-      "    },\n",
-      "    \"provider\": {\n",
-      "        \"first_name\": \"JEROME\",\n",
-      "        \"last_name\": \"AYA-AY\",\n",
-      "        \"npi\": \"1467560003\"\n",
-      "    },\n",
-      "    \"service_types\": [\"health_benefit_plan_coverage\"],\n",
-      "    \"trading_partner_id\": \"MOCKPAYER\"\n",
-      "})"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Claims"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "pd.claims({\n",
-      "    \"transaction_code\": \"chargeable\",\n",
-      "    \"trading_partner_id\": \"MOCKPAYER\",\n",
-      "    \"billing_provider\": {\n",
-      "        \"taxonomy_code\": \"207Q00000X\",\n",
-      "        \"first_name\": \"Jerome\",\n",
-      "        \"last_name\": \"Aya-Ay\",\n",
-      "        \"npi\": \"1467560003\",\n",
-      "        \"address\": {\n",
-      "            \"address_lines\": [\n",
-      "                \"8311 WARREN H ABERNATHY HWY\"\n",
-      "            ],\n",
-      "            \"city\": \"SPARTANBURG\",\n",
-      "            \"state\": \"SC\",\n",
-      "            \"zipcode\": \"29301\"\n",
-      "        },\n",
-      "        \"tax_id\": \"123456789\"\n",
-      "    },\n",
-      "    \"subscriber\": {\n",
-      "        \"first_name\": \"Jane\",\n",
-      "        \"last_name\": \"Doe\",\n",
-      "        \"member_id\": \"W000000000\",\n",
-      "        \"address\": {\n",
-      "            \"address_lines\": [\"123 N MAIN ST\"],\n",
-      "            \"city\": \"SPARTANBURG\",\n",
-      "            \"state\": \"SC\",\n",
-      "            \"zipcode\": \"29301\"\n",
-      "        },\n",
-      "        \"birth_date\": \"1970-01-01\",\n",
-      "        \"gender\": \"female\"\n",
-      "    },\n",
-      "    \"claim\": {\n",
-      "        \"total_charge_amount\": 60.0,\n",
-      "        \"service_lines\": [\n",
-      "            {\n",
-      "                \"procedure_code\": \"99213\",\n",
-      "                \"charge_amount\": 60.0,\n",
-      "                \"unit_count\": 1.0,\n",
-      "                \"diagnosis_codes\": [\n",
-      "                    \"487.1\"\n",
-      "                ],\n",
-      "                \"service_date\": \"2014-06-01\"\n",
-      "            }\n",
-      "        ]\n",
-      "    }\n",
-      "})"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "X12 Files"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "pd.files('MOCKPAYER', '/x12_files/eligibility_requests_batch_20.270')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Activities"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "pd.activities(activity_id='[one of your activity ids]')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "pd.activities()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    }
-   ],
-   "metadata": {}
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Connect and Authenticate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import pokitdok\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "client_id = os.environ['PD_CLIENT_ID']\n",
+    "client_secret = os.environ['PD_CLIENT_SECRET']\n",
+    "\n",
+    "base_url = 'http://localhost:5002'\n",
+    "\n",
+    "if not base_url.startswith('https'):\n",
+    "    os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'\n",
+    "\n",
+    "#pd = pokitdok.api.connect('[your client id]', '[your client secret]')\n",
+    "pd = pokitdok.api.connect(client_id, client_secret, base=base_url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Prices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pd.cash_prices(zip_code='32218', cpt_code='87799')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pd.insurance_prices(zip_code='32218', cpt_code='87799')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Providers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pd.providers(npi='1467560003')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pd.providers(first_name='Jerome', last_name='Aya-Ay')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pd.providers(organization_name='Qliance')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pd.providers(zipcode='29307', radius='10mi')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pd.providers(zipcode='29307', radius='10mi', specialty='RHEUMATOLOGY')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Eligibility"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pd.eligibility({\n",
+    "    \"member\": {\n",
+    "        \"birth_date\": \"1970-01-01\",\n",
+    "        \"first_name\": \"Jane\",\n",
+    "        \"last_name\": \"Doe\",\n",
+    "        \"id\": \"W000000000\"\n",
+    "    },\n",
+    "    \"provider\": {\n",
+    "        \"first_name\": \"JEROME\",\n",
+    "        \"last_name\": \"AYA-AY\",\n",
+    "        \"npi\": \"1467560003\"\n",
+    "    },\n",
+    "    \"service_types\": [\"health_benefit_plan_coverage\"],\n",
+    "    \"trading_partner_id\": \"MOCKPAYER\"\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Claims"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pd.claims({\n",
+    "    \"transaction_code\": \"chargeable\",\n",
+    "    \"trading_partner_id\": \"MOCKPAYER\",\n",
+    "    \"billing_provider\": {\n",
+    "        \"taxonomy_code\": \"207Q00000X\",\n",
+    "        \"first_name\": \"Jerome\",\n",
+    "        \"last_name\": \"Aya-Ay\",\n",
+    "        \"npi\": \"1467560003\",\n",
+    "        \"address\": {\n",
+    "            \"address_lines\": [\n",
+    "                \"8311 WARREN H ABERNATHY HWY\"\n",
+    "            ],\n",
+    "            \"city\": \"SPARTANBURG\",\n",
+    "            \"state\": \"SC\",\n",
+    "            \"zipcode\": \"29301\"\n",
+    "        },\n",
+    "        \"tax_id\": \"123456789\"\n",
+    "    },\n",
+    "    \"subscriber\": {\n",
+    "        \"first_name\": \"Jane\",\n",
+    "        \"last_name\": \"Doe\",\n",
+    "        \"member_id\": \"W000000000\",\n",
+    "        \"address\": {\n",
+    "            \"address_lines\": [\"123 N MAIN ST\"],\n",
+    "            \"city\": \"SPARTANBURG\",\n",
+    "            \"state\": \"SC\",\n",
+    "            \"zipcode\": \"29301\"\n",
+    "        },\n",
+    "        \"birth_date\": \"1970-01-01\",\n",
+    "        \"gender\": \"female\"\n",
+    "    },\n",
+    "    \"claim\": {\n",
+    "        \"total_charge_amount\": 60.0,\n",
+    "        \"service_lines\": [\n",
+    "            {\n",
+    "                \"procedure_code\": \"99213\",\n",
+    "                \"charge_amount\": 60.0,\n",
+    "                \"unit_count\": 1.0,\n",
+    "                \"diagnosis_codes\": [\n",
+    "                    \"487.1\"\n",
+    "                ],\n",
+    "                \"service_date\": \"2014-06-01\"\n",
+    "            }\n",
+    "        ]\n",
+    "    }\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### X12 Files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pd.files('MOCKPAYER', '/x12_files/eligibility_requests_batch_20.270')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Activities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pd.activities(activity_id='[one of your activity ids]')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pd.activities()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "### Identity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Identity POST"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "identity_data = {\n",
+    "        \"prefix\": \"Mr.\",\n",
+    "        \"first_name\": \"Oscar\",\n",
+    "        \"middle_name\": \"Harold\",\n",
+    "        \"last_name\": \"Whitmire\",\n",
+    "        \"suffix\": \"IV\",\n",
+    "        \"birth_date\": \"2000-05-01\",\n",
+    "        \"gender\": \"male\",\n",
+    "        \"email\": \"oscar@pokitdok.com\",\n",
+    "        \"phone\": \"555-555-5555\",\n",
+    "        \"secondary_phone\": \"333-333-4444\",\n",
+    "        \"address\": {\n",
+    "            \"address_lines\": [\"1400 Anyhoo Avenue\"],\n",
+    "            \"city\": \"Springfield\",\n",
+    "            \"state\": \"IL\",\n",
+    "            \"zipcode\": \"90210\"\n",
+    "        },\n",
+    "        \"identifiers\": [\n",
+    "            {\n",
+    "                \"location\": [-121.93831, 37.53901], \n",
+    "                \"provider_uuid\": \"1917f12b-fb6a-4016-93bc-adeb83204c83\",\n",
+    "                \"system_uuid\": \"967d207f-b024-41cc-8cac-89575a1f6fef\",\n",
+    "                \"value\": \"W90100-IG-88\"\n",
+    "                \n",
+    "            }\n",
+    "        ]\n",
+    "}\n",
+    "\n",
+    "pd.create_identity(identity_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Identity GET (uuid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pd.identity(identity_uuid='[identity uuid]')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Identity GET"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pd.identity(first_name='Oscar', last_name='Whitmire', gender='male')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "#### Identity PUT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "identity_data = {\n",
+    "        \"prefix\": \"Mr.\",\n",
+    "        \"first_name\": \"Oscar\",\n",
+    "        \"middle_name\": \"Harold\",\n",
+    "        \"last_name\": \"Whitmire\",\n",
+    "        \"suffix\": \"IV\",\n",
+    "        \"birth_date\": \"2000-05-01\",\n",
+    "        \"gender\": \"male\",\n",
+    "        \"email\": \"oscar@pokitdok.com\",\n",
+    "        \"phone\": \"555-555-5555\",\n",
+    "        \"secondary_phone\": \"333-333-4444\",\n",
+    "        \"address\": {\n",
+    "            \"address_lines\": [\"1400 Anyhoo Avenue\"],\n",
+    "            \"city\": \"Springfield\",\n",
+    "            \"state\": \"IL\",\n",
+    "            \"zipcode\": \"90210\"\n",
+    "        },\n",
+    "        \"identifiers\": [\n",
+    "            {\n",
+    "                \"location\": [-121.93831, 37.53901], \n",
+    "                \"provider_uuid\": \"1917f12b-fb6a-4016-93bc-adeb83204c83\",\n",
+    "                \"system_uuid\": \"967d207f-b024-41cc-8cac-89575a1f6fef\",\n",
+    "                \"value\": \"W90100-IG-88\"\n",
+    "                \n",
+    "            }\n",
+    "        ]}\n",
+    "\n",
+    "pd.update_identity('[identity_uuid]', identity_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/pokitdok/api/client.py
+++ b/pokitdok/api/client.py
@@ -410,3 +410,35 @@ class PokitDokClient(object):
         appointments_url = "{0}/schedule/appointments/{1}".format(self.url_base, appointment_uuid)
         return self.api_client.delete(appointments_url, headers=self.base_headers).json()
 
+    def create_identity(self, identity_request):
+        """
+            Creates an identity resource.
+            :param identity_request: The dictionary containing the identity request data.
+            :returns: The new identity resource.
+        """
+        identity_url = "{0}/identity/".format(self.url_base)
+        return self.api_client.post(identity_url, data=json.dumps(identity_request), headers=self.json_headers).json()
+
+    def update_identity(self, identity_uuid, identity_request):
+        """
+           Updates an existing identity resource.
+           :param identity_uuid: The identity resource's uuid.
+           :param identity_request: The updated identity resource.
+           :returns: The updated identity resource.
+        """
+        identity_url = "{0}/identity/{1}".format(self.url_base, identity_uuid)
+        return self.api_client.put(identity_url, data=json.dumps(identity_request), headers=self.json_headers).json()
+
+    def identity(self, identity_uuid=None, **kwargs):
+        """
+            Queries for an existing identity resource by uuid or for multiple resources using parameters.
+            :uuid: The identity resource uuid. Used to execute an exact match query by uuid.
+            :kwargs: Additional query parameters using resource fields such as first_name, last_name, email, etc.
+            :returns: zero or one result if uuid is used. Zero or more results if kwargs are used.
+        """
+        identity_url = "{0}/identity".format(self.url_base)
+
+        if identity_uuid:
+            identity_url += "/{0}".format(identity_uuid)
+
+        return self.api_client.get(identity_url, params=kwargs, headers=self.json_headers).json()

--- a/pokitdok/api/client.py
+++ b/pokitdok/api/client.py
@@ -441,4 +441,4 @@ class PokitDokClient(object):
         if identity_uuid:
             identity_url += "/{0}".format(identity_uuid)
 
-        return self.api_client.get(identity_url, params=kwargs, headers=self.json_headers).json()
+        return self.api_client.get(identity_url, params=kwargs, headers=self.base_headers).json()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import setup
 
 setup(
     name="pokitdok",
-    version="1.3",
+    version="1.4",
     license="MIT",
     author="PokitDok, Inc.",
     author_email="platform@pokitdok.com",

--- a/tests/fixtures/vcr_cassettes/create-identity.yml
+++ b/tests/fixtures/vcr_cassettes/create-identity.yml
@@ -1,0 +1,42 @@
+interactions:
+- request:
+    body: !!binary |
+      eyJhZGRyZXNzIjogeyJjaXR5IjogIkNoYXJsZXN0b24iLCAiemlwY29kZSI6ICIyOTQwNyIsICJz
+      dGF0ZSI6ICJTQyIsICJhZGRyZXNzX2xpbmVzIjogWyIxNTQyIEFueXdoZXJlIEF2ZW51ZSJdfSwg
+      ImdlbmRlciI6ICJmZW1hbGUiLCAiZW1haWwiOiAicGVnZ3lAcG9raXRkb2suY29tIiwgInByZWZp
+      eCI6ICJNcyIsICJsYXN0X25hbWUiOiAiUG9raXREb2siLCAiYmlydGhfZGF0ZSI6ICIxOTkxLTA1
+      LTE5IiwgImZpcnN0X25hbWUiOiAiUGVnIiwgImlkZW50aWZpZXJzIjogW3sicHJvdmlkZXJfdXVp
+      ZCI6ICI3NDg1MGY2NS02YmI3LTQ4ZTEtOWZjYi1iYzk4YzhkZGEyYmEiLCAic3lzdGVtX3V1aWQi
+      OiAiOTY3ZDIwN2YtYjAyNC00MWNjLThjYWMtODk1NzVhMWY2ZmVmIiwgInZhbHVlIjogIlc5MDEw
+      MC1JRy04OCIsICJsb2NhdGlvbiI6IFstODAuMDQwNiwgMzIuODk4Nl19XX0=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['443']
+      Content-type: [application/json]
+      User-Agent: [python-pokitdok/1.3 python-requests/2.9.1]
+    method: POST
+    uri: http://localhost:5002/api/v4/identity/
+  response:
+    body: {string: '{"meta": {"rate_limit_amount": 8, "rate_limit_reset": 1452725166,
+        "application_mode": "test", "processing_time": 7, "rate_limit_cap": 1000000000,
+        "credits_remaining": -15, "activity_id": "5696ccf80640fd4f8fedfcf0", "credits_billed":
+        1}, "data": {"first_name": "Peg", "last_name": "PokitDok", "app_name": "Platform
+        Test App", "gender": "female", "identifiers": [{"system_uuid": "967d207f-b024-41cc-8cac-89575a1f6fef",
+        "value": "W90100-IG-88", "update_datetime": "2016-01-13T22:17:28.725814",
+        "provider_uuid": "74850f65-6bb7-48e1-9fcb-bc98c8dda2ba", "insert_datetime":
+        "2016-01-13T22:17:28.725814", "location": [-80.0406, 32.8986]}], "update_datetime":
+        "2016-01-13T22:17:28.725814", "prefix": "Ms", "client_id": "43Z1u3NlPWzYFZp6nAht",
+        "address": {"address_lines": ["1542 Anywhere Avenue"], "state": "SC", "zipcode":
+        "29407", "city": "Charleston"}, "birth_date": "1991-05-19", "insert_datetime":
+        "2016-01-13T22:17:28.725814", "email": "peggy@pokitdok.com", "uuid": "0f1b8806-29ec-454c-b471-820c6eff0b8e"}}'}
+    headers:
+      Content-Length: ['1003']
+      Content-Type: [text/html; charset=utf-8]
+      Date: ['Wed, 13 Jan 2016 22:17:28 GMT']
+      Server: [Werkzeug/0.9.4 Python/2.7.6]
+      charset: [utf-8]
+      mimetype: [application/json]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/vcr_cassettes/identity-params.yml
+++ b/tests/fixtures/vcr_cassettes/identity-params.yml
@@ -1,0 +1,62 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-type: [application/json]
+      User-Agent: [python-pokitdok/1.3 python-requests/2.9.1]
+    method: GET
+    uri: http://localhost:5002/api/v4/identity?last_name=PokitDok&gender=female&prefix=Ms.&first_name=Peg
+  response:
+    body: {string: '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+
+        <title>Redirecting...</title>
+
+        <h1>Redirecting...</h1>
+
+        <p>You should be redirected automatically to target URL: <a href="http://localhost:5002/api/v4/identity/?last_name=PokitDok&amp;gender=female&amp;prefix=Ms.&amp;first_name=Peg">http://localhost:5002/api/v4/identity/?last_name=PokitDok&amp;gender=female&amp;prefix=Ms.&amp;first_name=Peg</a>.  If
+        not click the link.'}
+    headers:
+      Content-Length: ['425']
+      Content-Type: [text/html; charset=utf-8]
+      Date: ['Wed, 13 Jan 2016 22:17:28 GMT']
+      Location: ['http://localhost:5002/api/v4/identity/?last_name=PokitDok&gender=female&prefix=Ms.&first_name=Peg']
+      Server: [Werkzeug/0.9.4 Python/2.7.6]
+    status: {code: 301, message: MOVED PERMANENTLY}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-type: [application/json]
+      User-Agent: [python-pokitdok/1.3 python-requests/2.9.1]
+    method: GET
+    uri: http://localhost:5002/api/v4/identity/?last_name=PokitDok&gender=female&prefix=Ms.&first_name=Peg
+  response:
+    body: {string: '{"meta": {"rate_limit_amount": 9, "rate_limit_reset": 1452725166,
+        "application_mode": "test", "processing_time": 28, "rate_limit_cap": 1000000000,
+        "credits_remaining": -16, "activity_id": "5696ccf80640fd4f8fedfcf1", "credits_billed":
+        1}, "data": [{"first_name": "Peg", "last_name": "PokitDok", "middle_name":
+        "Harold", "app_name": "Platform Test App", "gender": "female", "member_id":
+        "W2000-05-01-001", "update_datetime": "2016-01-13T20:28:02.936024", "identifiers":
+        [{"system_uuid": "967d207f-b024-41cc-8cac-89575a1f6fef", "value": "W90100-IG-88",
+        "update_datetime": "2016-01-13T20:28:02.935520", "provider_uuid": "74850f65-6bb7-48e1-9fcb-bc98c8dda2ba",
+        "insert_datetime": "2016-01-13T20:28:02.935490", "location": [80.0406, 32.8986]}],
+        "phone": "555-555-5555", "prefix": "Ms.", "ssn": "333-22-4444", "suffix":
+        "IV", "client_id": "43Z1u3NlPWzYFZp6nAht", "address": {"address_lines": ["1400
+        Anyhoo Avenue"], "state": "IL", "zipcode": "90210", "city": "Springfield"},
+        "birth_date": "2000-05-01", "uuid": "4d04d8dc-3d0b-4ea1-8add-4dbc9619e1af",
+        "insert_datetime": "2016-01-13T20:28:02.935985", "email": "oscar-the-dog@pokitdok.com",
+        "secondary_phone": "555-552-5555"}]}'}
+    headers:
+      Content-Length: ['1168']
+      Content-Type: [text/html; charset=utf-8]
+      Date: ['Wed, 13 Jan 2016 22:17:28 GMT']
+      Server: [Werkzeug/0.9.4 Python/2.7.6]
+      charset: [utf-8]
+      mimetype: [application/json]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/vcr_cassettes/identity-params.yml
+++ b/tests/fixtures/vcr_cassettes/identity-params.yml
@@ -5,10 +5,9 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-type: [application/json]
       User-Agent: [python-pokitdok/1.3 python-requests/2.9.1]
     method: GET
-    uri: http://localhost:5002/api/v4/identity?last_name=PokitDok&gender=female&prefix=Ms.&first_name=Peg
+    uri: http://localhost:5002/api/v4/identity?gender=female&last_name=PokitDok&prefix=Ms.&first_name=Peg
   response:
     body: {string: '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 
@@ -16,13 +15,13 @@ interactions:
 
         <h1>Redirecting...</h1>
 
-        <p>You should be redirected automatically to target URL: <a href="http://localhost:5002/api/v4/identity/?last_name=PokitDok&amp;gender=female&amp;prefix=Ms.&amp;first_name=Peg">http://localhost:5002/api/v4/identity/?last_name=PokitDok&amp;gender=female&amp;prefix=Ms.&amp;first_name=Peg</a>.  If
+        <p>You should be redirected automatically to target URL: <a href="http://localhost:5002/api/v4/identity/?gender=female&amp;last_name=PokitDok&amp;prefix=Ms.&amp;first_name=Peg">http://localhost:5002/api/v4/identity/?gender=female&amp;last_name=PokitDok&amp;prefix=Ms.&amp;first_name=Peg</a>.  If
         not click the link.'}
     headers:
       Content-Length: ['425']
       Content-Type: [text/html; charset=utf-8]
-      Date: ['Wed, 13 Jan 2016 22:17:28 GMT']
-      Location: ['http://localhost:5002/api/v4/identity/?last_name=PokitDok&gender=female&prefix=Ms.&first_name=Peg']
+      Date: ['Thu, 14 Jan 2016 01:22:14 GMT']
+      Location: ['http://localhost:5002/api/v4/identity/?gender=female&last_name=PokitDok&prefix=Ms.&first_name=Peg']
       Server: [Werkzeug/0.9.4 Python/2.7.6]
     status: {code: 301, message: MOVED PERMANENTLY}
 - request:
@@ -31,30 +30,29 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-type: [application/json]
       User-Agent: [python-pokitdok/1.3 python-requests/2.9.1]
     method: GET
-    uri: http://localhost:5002/api/v4/identity/?last_name=PokitDok&gender=female&prefix=Ms.&first_name=Peg
+    uri: http://localhost:5002/api/v4/identity/?gender=female&last_name=PokitDok&prefix=Ms.&first_name=Peg
   response:
-    body: {string: '{"meta": {"rate_limit_amount": 9, "rate_limit_reset": 1452725166,
-        "application_mode": "test", "processing_time": 28, "rate_limit_cap": 1000000000,
-        "credits_remaining": -16, "activity_id": "5696ccf80640fd4f8fedfcf1", "credits_billed":
+    body: {string: '{"meta": {"rate_limit_amount": 1, "rate_limit_reset": 1452738134,
+        "application_mode": "test", "processing_time": 9, "rate_limit_cap": 1000000000,
+        "credits_remaining": -1, "activity_id": "5696f8460640fd7d215962b3", "credits_billed":
         1}, "data": [{"first_name": "Peg", "last_name": "PokitDok", "middle_name":
         "Harold", "app_name": "Platform Test App", "gender": "female", "member_id":
-        "W2000-05-01-001", "update_datetime": "2016-01-13T20:28:02.936024", "identifiers":
+        "W2000-05-01-001", "update_datetime": "2016-01-14T01:21:54.168813", "identifiers":
         [{"system_uuid": "967d207f-b024-41cc-8cac-89575a1f6fef", "value": "W90100-IG-88",
-        "update_datetime": "2016-01-13T20:28:02.935520", "provider_uuid": "74850f65-6bb7-48e1-9fcb-bc98c8dda2ba",
-        "insert_datetime": "2016-01-13T20:28:02.935490", "location": [80.0406, 32.8986]}],
+        "update_datetime": "2016-01-14T01:21:54.168325", "provider_uuid": "74850f65-6bb7-48e1-9fcb-bc98c8dda2ba",
+        "insert_datetime": "2016-01-14T01:21:54.168299", "location": [80.0406, 32.8986]}],
         "phone": "555-555-5555", "prefix": "Ms.", "ssn": "333-22-4444", "suffix":
         "IV", "client_id": "43Z1u3NlPWzYFZp6nAht", "address": {"address_lines": ["1400
         Anyhoo Avenue"], "state": "IL", "zipcode": "90210", "city": "Springfield"},
         "birth_date": "2000-05-01", "uuid": "4d04d8dc-3d0b-4ea1-8add-4dbc9619e1af",
-        "insert_datetime": "2016-01-13T20:28:02.935985", "email": "oscar-the-dog@pokitdok.com",
+        "insert_datetime": "2016-01-14T01:21:54.168775", "email": "oscar-the-dog@pokitdok.com",
         "secondary_phone": "555-552-5555"}]}'}
     headers:
-      Content-Length: ['1168']
+      Content-Length: ['1166']
       Content-Type: [text/html; charset=utf-8]
-      Date: ['Wed, 13 Jan 2016 22:17:28 GMT']
+      Date: ['Thu, 14 Jan 2016 01:22:14 GMT']
       Server: [Werkzeug/0.9.4 Python/2.7.6]
       charset: [utf-8]
       mimetype: [application/json]

--- a/tests/fixtures/vcr_cassettes/identity-uuid.yml
+++ b/tests/fixtures/vcr_cassettes/identity-uuid.yml
@@ -1,0 +1,36 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-type: [application/json]
+      User-Agent: [python-pokitdok/1.3 python-requests/2.9.1]
+    method: GET
+    uri: http://localhost:5002/api/v4/identity/881bc095-2068-43cb-9783-cce630364122
+  response:
+    body: {string: '{"meta": {"rate_limit_amount": 10, "rate_limit_reset": 1452725166,
+        "application_mode": "test", "processing_time": 7, "rate_limit_cap": 1000000000,
+        "credits_remaining": -17, "activity_id": "5696ccf80640fd4f8fedfcf2", "credits_billed":
+        1}, "data": {"first_name": "Oscar", "last_name": "Whitmire", "middle_name":
+        "Harold", "app_name": "Platform Test App", "gender": "male", "member_id":
+        "W2000-05-01-001", "update_datetime": "2016-01-13T20:28:02.936024", "identifiers":
+        [{"system_uuid": "967d207f-b024-41cc-8cac-89575a1f6fef", "value": "W90100-IG-88",
+        "update_datetime": "2016-01-13T20:28:02.935520", "provider_uuid": "74850f65-6bb7-48e1-9fcb-bc98c8dda2ba",
+        "insert_datetime": "2016-01-13T20:28:02.935490", "location": [80.0406, 32.8986]}],
+        "phone": "555-555-5555", "prefix": "Mr.", "ssn": "333-22-4444", "suffix":
+        "IV", "client_id": "43Z1u3NlPWzYFZp6nAht", "address": {"address_lines": ["1400
+        Anyhoo Avenue"], "state": "IL", "zipcode": "90210", "city": "Springfield"},
+        "birth_date": "2000-05-01", "uuid": "881bc095-2068-43cb-9783-cce630364122",
+        "insert_datetime": "2016-01-13T20:28:02.935985", "email": "oscar-the-dog@pokitdok.com",
+        "secondary_phone": "555-552-5555"}}'}
+    headers:
+      Content-Length: ['1166']
+      Content-Type: [text/html; charset=utf-8]
+      Date: ['Wed, 13 Jan 2016 22:17:28 GMT']
+      Server: [Werkzeug/0.9.4 Python/2.7.6]
+      charset: [utf-8]
+      mimetype: [application/json]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/vcr_cassettes/identity-uuid.yml
+++ b/tests/fixtures/vcr_cassettes/identity-uuid.yml
@@ -5,30 +5,29 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-type: [application/json]
       User-Agent: [python-pokitdok/1.3 python-requests/2.9.1]
     method: GET
     uri: http://localhost:5002/api/v4/identity/881bc095-2068-43cb-9783-cce630364122
   response:
-    body: {string: '{"meta": {"rate_limit_amount": 10, "rate_limit_reset": 1452725166,
+    body: {string: '{"meta": {"rate_limit_amount": 2, "rate_limit_reset": 1452738134,
         "application_mode": "test", "processing_time": 7, "rate_limit_cap": 1000000000,
-        "credits_remaining": -17, "activity_id": "5696ccf80640fd4f8fedfcf2", "credits_billed":
+        "credits_remaining": -2, "activity_id": "5696f8460640fd7d215962b4", "credits_billed":
         1}, "data": {"first_name": "Oscar", "last_name": "Whitmire", "middle_name":
         "Harold", "app_name": "Platform Test App", "gender": "male", "member_id":
-        "W2000-05-01-001", "update_datetime": "2016-01-13T20:28:02.936024", "identifiers":
+        "W2000-05-01-001", "update_datetime": "2016-01-14T01:21:54.168813", "identifiers":
         [{"system_uuid": "967d207f-b024-41cc-8cac-89575a1f6fef", "value": "W90100-IG-88",
-        "update_datetime": "2016-01-13T20:28:02.935520", "provider_uuid": "74850f65-6bb7-48e1-9fcb-bc98c8dda2ba",
-        "insert_datetime": "2016-01-13T20:28:02.935490", "location": [80.0406, 32.8986]}],
+        "update_datetime": "2016-01-14T01:21:54.168325", "provider_uuid": "74850f65-6bb7-48e1-9fcb-bc98c8dda2ba",
+        "insert_datetime": "2016-01-14T01:21:54.168299", "location": [80.0406, 32.8986]}],
         "phone": "555-555-5555", "prefix": "Mr.", "ssn": "333-22-4444", "suffix":
         "IV", "client_id": "43Z1u3NlPWzYFZp6nAht", "address": {"address_lines": ["1400
         Anyhoo Avenue"], "state": "IL", "zipcode": "90210", "city": "Springfield"},
         "birth_date": "2000-05-01", "uuid": "881bc095-2068-43cb-9783-cce630364122",
-        "insert_datetime": "2016-01-13T20:28:02.935985", "email": "oscar-the-dog@pokitdok.com",
+        "insert_datetime": "2016-01-14T01:21:54.168775", "email": "oscar-the-dog@pokitdok.com",
         "secondary_phone": "555-552-5555"}}'}
     headers:
-      Content-Length: ['1166']
+      Content-Length: ['1164']
       Content-Type: [text/html; charset=utf-8]
-      Date: ['Wed, 13 Jan 2016 22:17:28 GMT']
+      Date: ['Thu, 14 Jan 2016 01:22:14 GMT']
       Server: [Werkzeug/0.9.4 Python/2.7.6]
       charset: [utf-8]
       mimetype: [application/json]

--- a/tests/fixtures/vcr_cassettes/update-identity.yml
+++ b/tests/fixtures/vcr_cassettes/update-identity.yml
@@ -1,0 +1,42 @@
+interactions:
+- request:
+    body: !!binary |
+      eyJhZGRyZXNzIjogeyJjaXR5IjogIkNoYXJsZXN0b24iLCAiemlwY29kZSI6ICIyOTQwNyIsICJz
+      dGF0ZSI6ICJTQyIsICJhZGRyZXNzX2xpbmVzIjogWyIxNTQyIEFueXdoZXJlIEF2ZW51ZSJdfSwg
+      ImdlbmRlciI6ICJmZW1hbGUiLCAiZW1haWwiOiAicGVnZ3lAcG9raXRkb2suY29tIiwgInByZWZp
+      eCI6ICJNcyIsICJsYXN0X25hbWUiOiAiUG9raXREb2siLCAiYmlydGhfZGF0ZSI6ICIxOTkxLTA1
+      LTE5IiwgImZpcnN0X25hbWUiOiAiUGVnIiwgImlkZW50aWZpZXJzIjogW3sicHJvdmlkZXJfdXVp
+      ZCI6ICI3NDg1MGY2NS02YmI3LTQ4ZTEtOWZjYi1iYzk4YzhkZGEyYmEiLCAic3lzdGVtX3V1aWQi
+      OiAiOTY3ZDIwN2YtYjAyNC00MWNjLThjYWMtODk1NzVhMWY2ZmVmIiwgInZhbHVlIjogIlc5MDEw
+      MC1JRy04OCIsICJsb2NhdGlvbiI6IFstODAuMDQwNiwgMzIuODk4Nl19XX0=
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['443']
+      Content-type: [application/json]
+      User-Agent: [python-pokitdok/1.3 python-requests/2.9.1]
+    method: PUT
+    uri: http://localhost:5002/api/v4/identity/881bc095-2068-43cb-9783-cce630364122
+  response:
+    body: {string: '{"meta": {"rate_limit_amount": 11, "rate_limit_reset": 1452725166,
+        "application_mode": "test", "processing_time": 9, "rate_limit_cap": 1000000000,
+        "credits_remaining": -18, "activity_id": "5696ccf80640fd4f8fedfcf3", "credits_billed":
+        1}, "data": {"first_name": "Peg", "last_name": "PokitDok", "app_name": "Platform
+        Test App", "gender": "female", "identifiers": [{"system_uuid": "967d207f-b024-41cc-8cac-89575a1f6fef",
+        "value": "W90100-IG-88", "update_datetime": "2016-01-13T20:28:02.935520",
+        "provider_uuid": "74850f65-6bb7-48e1-9fcb-bc98c8dda2ba", "insert_datetime":
+        "2016-01-13T20:28:02.935490", "location": [-80.0406, 32.8986]}], "update_datetime":
+        "2016-01-13T20:28:02.936024", "prefix": "Ms", "client_id": "43Z1u3NlPWzYFZp6nAht",
+        "address": {"address_lines": ["1542 Anywhere Avenue"], "state": "SC", "zipcode":
+        "29407", "city": "Charleston"}, "birth_date": "1991-05-19", "insert_datetime":
+        "2016-01-13T20:28:02.935985", "email": "peggy@pokitdok.com", "uuid": "881bc095-2068-43cb-9783-cce630364122"}}'}
+    headers:
+      Content-Length: ['1004']
+      Content-Type: [text/html; charset=utf-8]
+      Date: ['Wed, 13 Jan 2016 22:17:28 GMT']
+      Server: [Werkzeug/0.9.4 Python/2.7.6]
+      charset: [utf-8]
+      mimetype: [application/json]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -5,7 +5,6 @@ import pokitdok
 from unittest import TestCase
 import vcr
 
-
 # Fake client id/secret for local testing
 CLIENT_ID = 'F7q38MzlwOxUwTHb7jvk'
 CLIENT_SECRET = 'O8DRamKmKMLtSTPjK99eUlbfOQEc44VVmp8ARmcY'
@@ -321,5 +320,88 @@ class TestAPIClient(TestCase):
                 },
                 "description": "Welcome to M0d3rN Healthcare"
             })
+            assert "meta" in response
+            assert "data" in response
+
+    def test_identity_get_uuid(self):
+        with pd_vcr.use_cassette('identity-uuid.yml'):
+            identity_uuid = '881bc095-2068-43cb-9783-cce630364122'
+            response = self.pd.identity(identity_uuid)
+            assert "meta" in response
+            assert "data" in response
+
+    def test_identity_get_params(self):
+        with pd_vcr.use_cassette('identity-params.yml'):
+            params = {
+                "first_name": "Peg",
+                "last_name": "PokitDok",
+                "gender": "female",
+                "prefix": "Ms."
+            }
+            response = self.pd.identity(**params)
+            assert "meta" in response
+            assert "data" in response
+
+    def test_create_identity(self):
+        with pd_vcr.use_cassette('create-identity.yml'):
+            identity_resource = {
+                "prefix": "Ms",
+                "first_name": "Peg",
+                "last_name": "PokitDok",
+                "gender": "female",
+                "birth_date": "1991-05-19",
+                "email": "peggy@pokitdok.com",
+                "address": {
+                    "address_lines": ["1542 Anywhere Avenue"],
+                    "city": "Charleston",
+                    "state": "SC",
+                    "zipcode": "29407"
+                },
+                "identifiers": [
+                    {
+                        "location": [
+                                        -80.0406,
+                                        32.8986
+                                    ],
+                        "provider_uuid": "74850f65-6bb7-48e1-9fcb-bc98c8dda2ba",
+                        "system_uuid": "967d207f-b024-41cc-8cac-89575a1f6fef",
+                        "value": "W90100-IG-88"
+                    }
+                ]
+            }
+            response = self.pd.create_identity(identity_resource)
+            assert "meta" in response
+            assert "data" in response
+
+    def test_update_identity(self):
+        with pd_vcr.use_cassette('update-identity.yml'):
+            identity_resource = {
+                "prefix": "Ms",
+                "first_name": "Peg",
+                "last_name": "PokitDok",
+                "gender": "female",
+                "birth_date": "1991-05-19",
+                "email": "peggy@pokitdok.com",
+                "address": {
+                    "address_lines": ["1542 Anywhere Avenue"],
+                    "city": "Charleston",
+                    "state": "SC",
+                    "zipcode": "29407"
+                },
+                "identifiers": [
+                    {
+                        "location": [
+                                        -80.0406,
+                                        32.8986
+                                    ],
+                        "provider_uuid": "74850f65-6bb7-48e1-9fcb-bc98c8dda2ba",
+                        "system_uuid": "967d207f-b024-41cc-8cac-89575a1f6fef",
+                        "value": "W90100-IG-88"
+                    }
+                ]
+            }
+
+            identity_uuid = '881bc095-2068-43cb-9783-cce630364122'
+            response = self.pd.update_identity(identity_uuid, identity_resource)
             assert "meta" in response
             assert "data" in response


### PR DESCRIPTION
This PR adds support for the /identity endpoint which is used to manage identity resources within the Platform Health Graph.
Supported operations include:
- create_identity
- update_identity
- identity

The "identity" method is used for querying identity resources by uuid or fields.

Note: The Platform current supports /identity test mode endpoints. Production endpoints will be included in a future release.