### PR TITLE
PLATFORM-2949: update python client library to expose a generic request method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.6"
   - "2.7"
   - "3.4"
+  - "3.5"
   - "pypy"
 install: "pip install ."
 script: "python setup.py nosetests"

--- a/README.rst
+++ b/README.rst
@@ -16,11 +16,15 @@ Install from PyPI_ using pip_
 Resources
 ---------
 
-Report issues_ on GitHub
+See the documentation_ for detailed information on all of the PokitDok Platform APIs.
+
+Report API client issues_ on GitHub
 
 
 Quick start
 -----------
+
+The Quick Start Guide is also available as a Jupyter_ notebook_.
 
 .. code-block:: python
 
@@ -47,7 +51,7 @@ Quick start
     pd.providers(zipcode='29307', radius='10mi')
     pd.providers(zipcode='29307', radius='10mi', specialty='RHEUMATOLOGY')
 
-    #submit a v4 eligibility request
+    #submit an eligibility request
     pd.eligibility({
         "member": {
             "birth_date": "1970-01-01",
@@ -64,7 +68,7 @@ Quick start
         "trading_partner_id": "MOCKPAYER"
     })
 
-    #submit a v4 claims request
+    #submit a claims request
     pd.claims({
         "transaction_code": "chargeable",
         "trading_partner_id": "MOCKPAYER",
@@ -267,7 +271,7 @@ Quick start
             "benefit_status": "Active",
             "benefits": [
                 {
-                    "begin_date": " 2015-01-01",
+                    "begin_date": "2015-01-01",
                     "benefit_type": "Health",
                     "coordination_of_benefits": [
                         {
@@ -386,8 +390,54 @@ Quick start
     pd.identity(first_name='Oscar', last_name='Whitmire', gender='male')
 
 
-See the documentation_ for detailed information on all of the PokitDok Platform APIs.
-The Quick Start Guide is also available as an IPython_ notebook_.
+Making Requests
+---------------
+
+The client offers a few options for making API requests.
+High level functions are available for each of the APIs for convenience.
+If your application would prefer to interact with the APIs at a lower level,
+you may elect to use the general purpose request method or one of the http method aliases built around it.
+
+.. code-block:: python
+
+    # a low level "request" method is available that allows you to have more control over the construction of the API request
+    pd.request('/activities', method='get')
+
+    pd.request('/eligibility/', method='post', data={
+        "member": {
+            "birth_date": "1970-01-01",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "id": "W000000000"
+        },
+        "trading_partner_id": "MOCKPAYER"
+    })
+
+    # Convenience methods are available for the commonly used http methods built around the request method
+    pd.get('/activities')
+
+    pd.post('/eligibility/', data={
+        "member": {
+            "birth_date": "1970-01-01",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "id": "W000000000"
+        },
+        "trading_partner_id": "MOCKPAYER"
+    })
+
+    # higher level functions are also available to access the APIs
+    pd.activities()
+
+    pd.eligibility({
+        "member": {
+            "birth_date": "1970-01-01",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "id": "W000000000"
+        },
+        "trading_partner_id": "MOCKPAYER"
+    })
 
 
 Authentication and Authorization
@@ -459,6 +509,7 @@ This library aims to support and is tested against these Python versions:
 * 2.6.9
 * 2.7.6
 * 3.4.0
+* 3.5.0
 * PyPy
 
 You may have luck with other interpreters - let us know how it goes.
@@ -473,7 +524,7 @@ Copyright (c) 2014 PokitDok, Inc.  See LICENSE_ for details.
 .. _PyPI: https://pypi.python.org/pypi
 .. _pip: https://pypi.python.org/pypi/pip
 .. _LICENSE: LICENSE.txt
-.. _IPython: http://ipython.org/
+.. _Jupyter: http://jupyter.org/
 .. _notebook: notebooks/PlatformQuickStartDemo.ipynb
 
 .. |version| image:: https://badge.fury.io/py/pokitdok.svg

--- a/README.rst
+++ b/README.rst
@@ -238,6 +238,10 @@ The Quick Start Guide is also available as a Jupyter_ notebook_.
     #retrieve insurance plan information.  For example, EPO plans in Texas.
     pd.plans(state='TX', plan_type='EPO')
 
+    #look up medical procedure code information
+    pd.mpc(code='99213')
+    pd.mpc(name='office')
+
     #lookup a diagnosis mapping for the specified ICD-9 code
     pd.icd_convert('250.12')
 

--- a/notebooks/PlatformQuickStartDemo.ipynb
+++ b/notebooks/PlatformQuickStartDemo.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Connect and Authenticate"
+    "## Connect and Authenticate"
    ]
   },
   {
@@ -33,6 +33,153 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "_or_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "client_id = os.environ['POKITDOK_CLIENT_ID']\n",
+    "client_secret = os.environ['POKITDOK_CLIENT_SECRET']\n",
+    "pd = pokitdok.api.connect(client_id, client_secret)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Making API Requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# a low level \"request\" method is available that allows you to have more control over the construction of the API request\n",
+    "pd.request('/activities', method='get')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "pd.request('/eligibility/', method='post', data={\n",
+    "    \"member\": {\n",
+    "        \"birth_date\": \"1970-01-01\",\n",
+    "        \"first_name\": \"Jane\",\n",
+    "        \"last_name\": \"Doe\",\n",
+    "        \"id\": \"W000000000\"\n",
+    "    },\n",
+    "    \"trading_partner_id\": \"MOCKPAYER\"\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Convenience methods are available for the commonly used http methods built around the request method\n",
+    "pd.get('/activities')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "pd.post('/eligibility/', data={\n",
+    "    \"member\": {\n",
+    "        \"birth_date\": \"1970-01-01\",\n",
+    "        \"first_name\": \"Jane\",\n",
+    "        \"last_name\": \"Doe\",\n",
+    "        \"id\": \"W000000000\"\n",
+    "    },\n",
+    "    \"trading_partner_id\": \"MOCKPAYER\"\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# higher level functions are also available to access the APIs\n",
+    "pd.activities()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "pd.eligibility({\n",
+    "    \"member\": {\n",
+    "        \"birth_date\": \"1970-01-01\",\n",
+    "        \"first_name\": \"Jane\",\n",
+    "        \"last_name\": \"Doe\",\n",
+    "        \"id\": \"W000000000\"\n",
+    "    },\n",
+    "    \"trading_partner_id\": \"MOCKPAYER\"\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data APIs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Claims Convert"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#convert existing claims in a X12 837 file to claims request JSON.  ICD-9 codes are converted to ICD-10\n",
+    "pd.claims_convert('/path/to/my_claims.837')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Prices"
    ]
   },
@@ -44,6 +191,7 @@
    },
    "outputs": [],
    "source": [
+    "#retrieve cash price information by zip and CPT code\n",
     "pd.cash_prices(zip_code='32218', cpt_code='87799')"
    ]
   },
@@ -55,7 +203,27 @@
    },
    "outputs": [],
    "source": [
+    "#retrieve insurance price information by zip and CPT code\n",
     "pd.insurance_prices(zip_code='32218', cpt_code='87799')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plans"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#retrieve insurance plan information.  For example, EPO plans in Texas.\n",
+    "pd.plans(state='TX', plan_type='EPO')"
    ]
   },
   {
@@ -73,6 +241,7 @@
    },
    "outputs": [],
    "source": [
+    "#retrieve provider information by NPI\n",
     "pd.providers(npi='1467560003')"
    ]
   },
@@ -84,6 +253,7 @@
    },
    "outputs": [],
    "source": [
+    "#search providers by name (individuals)\n",
     "pd.providers(first_name='Jerome', last_name='Aya-Ay')"
    ]
   },
@@ -95,6 +265,7 @@
    },
    "outputs": [],
    "source": [
+    "#search providers by name (organizations)\n",
     "pd.providers(organization_name='Qliance')"
    ]
   },
@@ -106,6 +277,7 @@
    },
    "outputs": [],
    "source": [
+    "#search providers by location and/or specialty\n",
     "pd.providers(zipcode='29307', radius='10mi')"
    ]
   },
@@ -124,6 +296,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## X12 APIs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Eligibility"
    ]
   },
@@ -132,6 +311,25 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pd.eligibility({\n",
+    "    \"member\": {\n",
+    "        \"birth_date\": \"1970-01-01\",\n",
+    "        \"first_name\": \"Jane\",\n",
+    "        \"last_name\": \"Doe\",\n",
+    "        \"id\": \"W000000000\"\n",
+    "    },\n",
+    "    \"trading_partner_id\": \"MOCKPAYER\"\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -219,6 +417,247 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Claims Status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#Check the status of a claim\n",
+    "pd.claims_status({\n",
+    "    \"patient\": {\n",
+    "        \"birth_date\": \"1970-01-01\",\n",
+    "        \"first_name\": \"JANE\",\n",
+    "        \"last_name\": \"DOE\",\n",
+    "        \"id\": \"1234567890\"\n",
+    "    },\n",
+    "    \"provider\": {\n",
+    "        \"first_name\": \"Jerome\",\n",
+    "        \"last_name\": \"Aya-Ay\",\n",
+    "        \"npi\": \"1467560003\",\n",
+    "    },\n",
+    "    \"service_date\": \"2014-01-01\",\n",
+    "    \"trading_partner_id\": \"MOCKPAYER\"\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Authorizations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#Submit an authorization request\n",
+    "pd.authorizations({\n",
+    "    \"event\": {\n",
+    "        \"category\": \"health_services_review\",\n",
+    "        \"certification_type\": \"initial\",\n",
+    "        \"delivery\": {\n",
+    "            \"quantity\": 1,\n",
+    "            \"quantity_qualifier\": \"visits\"\n",
+    "        },\n",
+    "        \"diagnoses\": [\n",
+    "            {\n",
+    "                \"code\": \"789.00\",\n",
+    "                \"date\": \"2014-10-01\"\n",
+    "            }\n",
+    "        ],\n",
+    "        \"place_of_service\": \"office\",\n",
+    "        \"provider\": {\n",
+    "            \"organization_name\": \"KELLY ULTRASOUND CENTER, LLC\",\n",
+    "            \"npi\": \"1760779011\",\n",
+    "            \"phone\": \"8642341234\"\n",
+    "        },\n",
+    "        \"services\": [\n",
+    "            {\n",
+    "                \"cpt_code\": \"76700\",\n",
+    "                \"measurement\": \"unit\",\n",
+    "                \"quantity\": 1\n",
+    "            }\n",
+    "        ],\n",
+    "        \"type\": \"diagnostic_imaging\"\n",
+    "    },\n",
+    "    \"patient\": {\n",
+    "        \"birth_date\": \"1970-01-01\",\n",
+    "        \"first_name\": \"JANE\",\n",
+    "        \"last_name\": \"DOE\",\n",
+    "        \"id\": \"1234567890\"\n",
+    "    },\n",
+    "    \"provider\": {\n",
+    "        \"first_name\": \"JEROME\",\n",
+    "        \"npi\": \"1467560003\",\n",
+    "        \"last_name\": \"AYA-AY\"\n",
+    "    },\n",
+    "    \"trading_partner_id\": \"MOCKPAYER\"\n",
+    "})\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Referrals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#Submit a referral request\n",
+    "pd.referrals({\n",
+    "    \"event\": {\n",
+    "        \"category\": \"specialty_care_review\",\n",
+    "        \"certification_type\": \"initial\",\n",
+    "        \"delivery\": {\n",
+    "            \"quantity\": 1,\n",
+    "            \"quantity_qualifier\": \"visits\"\n",
+    "        },\n",
+    "        \"diagnoses\": [\n",
+    "            {\n",
+    "                \"code\": \"384.20\",\n",
+    "                \"date\": \"2014-09-30\"\n",
+    "            }\n",
+    "        ],\n",
+    "        \"place_of_service\": \"office\",\n",
+    "        \"provider\": {\n",
+    "            \"first_name\": \"JOHN\",\n",
+    "            \"npi\": \"1154387751\",\n",
+    "            \"last_name\": \"FOSTER\",\n",
+    "            \"phone\": \"8645822900\"\n",
+    "        },\n",
+    "        \"type\": \"consultation\"\n",
+    "    },\n",
+    "    \"patient\": {\n",
+    "        \"birth_date\": \"1970-01-01\",\n",
+    "        \"first_name\": \"JANE\",\n",
+    "        \"last_name\": \"DOE\",\n",
+    "        \"id\": \"1234567890\"\n",
+    "    },\n",
+    "    \"provider\": {\n",
+    "        \"first_name\": \"CHRISTINA\",\n",
+    "        \"last_name\": \"BERTOLAMI\",\n",
+    "        \"npi\": \"1619131232\"\n",
+    "    },\n",
+    "    \"trading_partner_id\": \"MOCKPAYER\"\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Enrollment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#Submit an enrollment request to establish benefits for a new employee\n",
+    "pd.enrollment({\n",
+    "    \"action\": \"Change\",\n",
+    "    \"dependents\": [],\n",
+    "    \"master_policy_number\": \"ABCD012354\",\n",
+    "    \"payer\": {\n",
+    "        \"tax_id\": \"654456654\"\n",
+    "    },\n",
+    "    \"purpose\": \"Original\",\n",
+    "    \"sponsor\": {\n",
+    "        \"tax_id\": \"999888777\"\n",
+    "    },\n",
+    "    \"subscriber\": {\n",
+    "        \"address\": {\n",
+    "            \"city\": \"CAMP HILL\",\n",
+    "            \"county\": \"CUMBERLAND\",\n",
+    "            \"line\": \"100 MARKET ST\",\n",
+    "            \"line2\": \"APT 3G\",\n",
+    "            \"postal_code\": \"17011\",\n",
+    "            \"state\": \"PA\"\n",
+    "        },\n",
+    "        \"benefit_status\": \"Active\",\n",
+    "        \"benefits\": [\n",
+    "            {\n",
+    "                \"begin_date\": \"2015-01-01\",\n",
+    "                \"benefit_type\": \"Health\",\n",
+    "                \"coordination_of_benefits\": [\n",
+    "                    {\n",
+    "                        \"group_or_policy_number\": \"890111\",\n",
+    "                        \"payer_responsibility\": \"Primary\",\n",
+    "                        \"status\": \"Unknown\"\n",
+    "                    }\n",
+    "                ],\n",
+    "                \"late_enrollment\": False,\n",
+    "                \"maintenance_type\": \"Addition\"\n",
+    "            },\n",
+    "            {\n",
+    "                \"begin_date\": \"2015-01-01\",\n",
+    "                \"benefit_type\": \"Dental\",\n",
+    "                \"late_enrollment\": False,\n",
+    "                \"maintenance_type\": \"Addition\"\n",
+    "            },\n",
+    "            {\n",
+    "                \"begin_date\": \"2015-01-01\",\n",
+    "                \"benefit_type\": \"Vision\",\n",
+    "                \"late_enrollment\": False,\n",
+    "                \"maintenance_type\": \"Addition\"\n",
+    "            }\n",
+    "        ],\n",
+    "        \"birth_date\": \"1940-01-01\",\n",
+    "        \"contacts\": [\n",
+    "            {\n",
+    "                \"communication_number2\": \"7172341240\",\n",
+    "                \"communication_type2\": \"Work Phone Number\",\n",
+    "                \"primary_communication_number\": \"7172343334\",\n",
+    "                \"primary_communication_type\": \"Home Phone Number\"\n",
+    "            }\n",
+    "        ],\n",
+    "        \"eligibility_begin_date\": \"2014-01-01\",\n",
+    "        \"employment_status\": \"Full-time\",\n",
+    "        \"first_name\": \"JOHN\",\n",
+    "        \"gender\": \"Male\",\n",
+    "        \"group_or_policy_number\": \"123456001\",\n",
+    "        \"handicapped\": False,\n",
+    "        \"last_name\": \"DOE\",\n",
+    "        \"maintenance_reason\": \"Active\",\n",
+    "        \"maintenance_type\": \"Addition\",\n",
+    "        \"member_id\": \"123456789\",\n",
+    "        \"middle_name\": \"P\",\n",
+    "        \"relationship\": \"Self\",\n",
+    "        \"ssn\": \"123456789\",\n",
+    "        \"subscriber_number\": \"123456789\",\n",
+    "        \"substance_abuse\": False,\n",
+    "        \"tobacco_use\": False\n",
+    "    },\n",
+    "    \"trading_partner_id\": \"MOCKPAYER\",\n",
+    "})\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### X12 Files"
    ]
   },
@@ -230,36 +669,8 @@
    },
    "outputs": [],
    "source": [
+    "#Submit X12 files directly for processing\n",
     "pd.files('MOCKPAYER', '/x12_files/eligibility_requests_batch_20.270')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Activities"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "pd.activities(activity_id='[one of your activity ids]')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "pd.activities()"
    ]
   },
   {
@@ -401,6 +812,116 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## Utility APIs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Activities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#Check on platform activities\n",
+    "#check on a specific activity\n",
+    "pd.activities(activity_id='[one of your activity ids]')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#retrieve an index of your application's activities\n",
+    "pd.activities()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#check on a batch of activities (useful to track the results of APIs like X12 files, Claims Convert, etc.)\n",
+    "pd.activities(parent_id='[one of your parent activity ids]')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Trading Partners"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#retrieve a specific trading_partner\n",
+    "pd.trading_partners(\"MOCKPAYER\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### ICD Convert"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#lookup a diagnosis mapping for the specified ICD-9 code\n",
+    "pd.icd_convert('250.12')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Enrollment Snapshot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#Use the specified X12 834 file as the current membership enrollment snapshot for a trading partner\n",
+    "pd.enrollment_snapshot('MOCKPAYER', '/path/to/current_membership_enrollment.834')"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -426,7 +947,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.5.0"
   }
  },
  "nbformat": 4,

--- a/notebooks/PlatformQuickStartDemo.ipynb
+++ b/notebooks/PlatformQuickStartDemo.ipynb
@@ -296,6 +296,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Medical Procedure Code (MPC)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "pd.mpc(code='99213')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## X12 APIs"
    ]
   },

--- a/pokitdok/__init__.py
+++ b/pokitdok/__init__.py
@@ -9,7 +9,7 @@
 from __future__ import absolute_import
 
 __title__ = 'pokitdok'
-__version__ = '1.4.2'
+__version__ = '1.5'
 __author__ = 'PokitDok, Inc.'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2014-2015 PokitDok, Inc.'

--- a/pokitdok/api/client.py
+++ b/pokitdok/api/client.py
@@ -424,7 +424,7 @@ class PokitDokClient(object):
             :returns: list containing the search results. A search by uuid returns an empty list or a list containing
             a single identity record.
         """
-        path = "/identity{0}".format('/{}'.format(identity_uuid) if identity_uuid else '')
+        path = "/identity{0}".format('/{0}'.format(identity_uuid) if identity_uuid else '')
         return self.get(path, **kwargs)
 
     def pharmacy_plans(self, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import setup
 
 setup(
     name="pokitdok",
-    version="1.4.2",
+    version="1.5",
     license="MIT",
     author="PokitDok, Inc.",
     author_email="platform@pokitdok.com",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py34,pypy
+envlist = py26,py27,py34,py35,pypy
 [testenv]
 deps=
     nose


### PR DESCRIPTION
These changes update the PokitDok Python client library to expose a generic `request` method (along with convenience methods for `get`, `put`, `post`, and `delete`). This allows Python developers to interact with future PokitDok Platform APIs as soon as they become available without needing to `pip install` a new version of the client library.   Higher level methods may still be added to the Python client library periodically for convenience. 