### PR TITLE
PLATFORM-3641: Associate client instance with existing access token

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import setup
 
 setup(
     name="pokitdok",
-    version="1.8",
+    version="1.9",
     license="MIT",
     author="PokitDok, Inc.",
     author_email="platform@pokitdok.com",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     author="PokitDok, Inc.",
     author_email="platform@pokitdok.com",
     url="https://platform.pokitdok.com",
-    download_url='https://github.com/pokitdok/pokitdok-python/tarball/1.8',
+    download_url='https://github.com/pokitdok/pokitdok-python/tarball/1.9',
     description="PokitDok Platform API Client",
     long_description=__doc__,
     packages=["pokitdok", "pokitdok.api"],

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -97,6 +97,25 @@ class TestAPIClient(object):
         assert self.pd_client.api_client is not None
         assert self.pd_client.api_client.token is not None
 
+    def test_connect_existing_token(self):
+        """
+            Tests pokitdok.api.connect (PokitDok.__init__()) with an existing token
+            Validates that the API client instantiation supports an existing token
+        """
+        with HTTMock(self.mock_oauth2_token):
+            self.pd_client = pokitdok.api.connect(self.CLIENT_ID, self.CLIENT_SECRET)
+            first_token = copy.deepcopy(self.pd_client.token)
+
+            self.pd_client = pokitdok.api.connect(self.CLIENT_ID, self.CLIENT_SECRET, token=first_token)
+            second_token = copy.deepcopy(self.pd_client.token)
+            # first token should be equal to the second
+            assert first_token == second_token
+
+            # validate unique tokens for new client instances
+            self.pd_client = pokitdok.api.connect(self.CLIENT_ID, self.CLIENT_SECRET)
+            third_token = copy.deepcopy(self.pd_client.token)
+            assert third_token not in [first_token, second_token]
+
     def test_request_post(self):
         """
             Tests the PokitDok.request convenience method with a POST request.


### PR DESCRIPTION
This PR updates the pokitdok-python client __init__() method to support associating an existing access token with a new client instance. This allows stateless clients to be more considerate of the Platform API server resources as access tokens may be reused.

For instance an application may cache it's API token on it its first API request.
Note: The "application_cache" in the code snippet below is a pseudo construct in the Platform application's code.

```
pd = connect(client_id, client_secret)
application_cache['token'] = pd.token
response = pd.<make-some-request>
```

On subsequent requests the token may be reused
```
pd = connect(client_id, client_secret, token=application_cache['token'])
response = pd.<make-some-request>
```

