### PR TITLE
PLATFORM-4011 auto_refresh access token

### DIFF
--- a/pokitdok/__init__.py
+++ b/pokitdok/__init__.py
@@ -9,7 +9,7 @@
 from __future__ import absolute_import
 
 __title__ = 'pokitdok'
-__version__ = '2.1'
+__version__ = '2.2'
 __author__ = 'PokitDok, Inc.'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2014-2016 PokitDok, Inc.'

--- a/pokitdok/api/client.py
+++ b/pokitdok/api/client.py
@@ -57,12 +57,19 @@ class PokitDokClient(object):
         self.code = code
         self.auto_refresh = auto_refresh
         self.token_refresh_callback = token_refresh_callback
+        # point to the token_updater for refreshing token
+        if self.token_refresh_callback is None:
+            self.token_refresh_callback = self.token_updater
         self.token = token
         self.url_base = "{0}/api/{1}".format(base, version)
         self.token_url = "{0}/oauth2/token".format(base)
         self.authorize_url = "{0}/oauth2/authorize".format(base)
         self.api_client = None
         self.fetch_access_token(code=self.code)
+
+    def token_updater(self, token):
+        if token is not None:
+            self.token = token
 
     def initialize_auth_api_client(self, refresh_url):
         self.api_client = OAuth2Session(self.client_id, redirect_uri=self.redirect_uri, scope=self.scope,

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,12 @@ from setuptools import setup
 
 setup(
     name="pokitdok",
-    version="2.1",
+    version="2.2",
     license="MIT",
     author="PokitDok, Inc.",
     author_email="platform@pokitdok.com",
     url="https://platform.pokitdok.com",
-    download_url='https://github.com/pokitdok/pokitdok-python/tarball/2.1',
+    download_url='https://github.com/pokitdok/pokitdok-python/tarball/2.2',
     description="PokitDok Platform API Client",
     long_description=__doc__,
     packages=["pokitdok", "pokitdok.api"],

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -600,3 +600,31 @@ class TestAPIClient(object):
             mocked_response = self.pd_client.pharmacy_network(trading_partner_id='MOCKPAYER', plan_number='S5596033',
                                                                 zipcode='94401', radius='10mi')
         assert mocked_response is not None
+
+    def test_connect_refresh_token(self):
+        """
+            Tests pokitdok.api.connect and getting a refresh token
+            Validates that the API client instantiation supports an existing token and refreshing a token for auto_refresh
+        """
+        with HTTMock(self.mock_oauth2_token):
+            # get token initial token
+            self.pd_client = pokitdok.api.connect(self.CLIENT_ID, self.CLIENT_SECRET, auto_refresh=True)
+            first_token = copy.deepcopy(self.pd_client.token)
+
+            # expire the token and make sure new token is created and not the same as first token
+            self.pd_client.token['expires_in'] = -10
+            self.pd_client.token['expires_at'] = ((datetime.datetime.utcnow() - datetime.timedelta(minutes=61)) - datetime.datetime(1970, 1, 1)).total_seconds()
+            self.pd_client = pokitdok.api.connect(self.CLIENT_ID, self.CLIENT_SECRET, token=self.pd_client.token, auto_refresh=True)
+
+            # attempt to make a call, which should get new token...thus auto_refresh working
+            mocked_response = self.pd_client.pharmacy_plans(trading_partner_id='MOCKPAYER', plan_number='S5820003')
+            assert mocked_response is not None
+            second_token = copy.deepcopy(self.pd_client.token)
+            assert first_token != second_token
+
+            # attempt to make a call, which should NOT get a new token. Shows that token_updater is working to
+            # reset token on PokitDokClient
+            mocked_response = self.pd_client.pharmacy_plans(trading_partner_id='MOCKPAYER', plan_number='S5820003')
+            assert mocked_response is not None
+            third_token = copy.deepcopy(self.pd_client.token)
+            assert second_token == third_token

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -613,7 +613,6 @@ class TestAPIClient(object):
 
             # expire the token and make sure new token is created and not the same as first token
             self.pd_client.token['expires_in'] = -10
-            self.pd_client.token['expires_at'] = ((datetime.datetime.utcnow() - datetime.timedelta(minutes=61)) - datetime.datetime(1970, 1, 1)).total_seconds()
             self.pd_client = pokitdok.api.connect(self.CLIENT_ID, self.CLIENT_SECRET, token=self.pd_client.token, auto_refresh=True)
 
             # attempt to make a call, which should get new token...thus auto_refresh working


### PR DESCRIPTION
This is the other half of the PR (https://github.com/PokitDokInc/pokit-flask/pull/37) for the pokit-flask, which returns the refresh_token when authenticating.  The only thing missing in the python client was having the refresh_token initially AND not having the "callback" method when the "auto refresh" happened (the token_updater method). 

Update: as of 8/8/2016.  Not going to make changes to pokit-flask to include refresh_token. Only going to update python client to handle the re-authentication and retry of request, if "TokenExpiredError" is caught.