### PR TITLE
Don't install `nose` for production

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,10 @@ setup(
     include_package_data=True,
     platforms="any",
     install_requires=[
-        "requests>=2.3.0", "oauthlib<0.7.0", "requests-oauthlib==0.4.1", "nose==1.3.7"
+        "requests>=2.3.0", "oauthlib<0.7.0", "requests-oauthlib==0.4.1",
     ],
     test_suite='nose.collector',
+    tests_require=["nose==1.3.7"],
     keywords=['health', 'api', 'pokitdok', 'X12', 'eligibility', 'claims', 'providers', 'prices', 'healthcare',
               'referrals', 'authorizations', 'insurance', 'plans', 'benefits', 'enrollment'],
     classifiers=[

--- a/setup_and_test.sh
+++ b/setup_and_test.sh
@@ -1,3 +1,3 @@
 cd /app/pokitdok/
 python setup.py develop
-nosetests tests/
+python setup.py test

--- a/setup_and_test_pypy.sh
+++ b/setup_and_test_pypy.sh
@@ -3,4 +3,4 @@ curl -SL 'https://bootstrap.pypa.io/get-pip.py' | pypy
 pip install --upgrade pip
 cd /app/pokitdok/
 python setup.py develop
-nosetests tests/
+python setup.py test


### PR DESCRIPTION
When a user tries to use the library in production, don't make them install `nose` as well.

Changed the test scripts to match; Now `python setup.py test` runs the tests.

Also removed empty file requirements.txt.