### PR TITLE
#28 Upgrade oauthlib to 0.7.2.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     include_package_data=True,
     platforms="any",
     install_requires=[
-        "requests>=2.3.0", "oauthlib<0.7.0", "requests-oauthlib==0.4.1",
+        "requests>=2.3.0", "oauthlib==0.7.2", "requests-oauthlib==0.4.1",
     ],
     test_suite='nose.collector',
     tests_require=["nose==1.3.7"],


### PR DESCRIPTION
This upgrade to oauthlib to 0.7.2 includes a security fix so that client passwords are not logged.
See https://github.com/oauthlib/oauthlib/blob/master/CHANGELOG.rst for the full changelog

The relevant security fix is in 0.7.0: (Fix/Security) OAuth2 logs will now strip client provided password, if present. I upgrade to 0.7.2 because 0.7.0 and 0.7.1 appear to both have mistakes in the release. 
This _should_ not be a breaking change, but definitely needs to be tested