### PR TITLE
Upgrade to oauthlib 0.7.2 with auto_refresh support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     include_package_data=True,
     platforms="any",
     install_requires=[
-        "requests>=2.3.0", "oauthlib<0.7.0", "requests-oauthlib==0.4.1",
+        "requests>=2.3.0", "oauthlib==0.7.2", "requests-oauthlib==0.4.1",
     ],
     test_suite='nose.collector',
     tests_require=["nose==1.3.7"],


### PR DESCRIPTION
This adjustment should help to resolve #28 that was reported by @ThomasWunderlich
Newer oauthlib versions stopped raising the `TokenExpiredError` when interacting with the PokitDok APIs.  This was related to some adjustments to the `expires_in` handling for tracking the token expiration.   Work is underway to adjust that in oauthlib.   In the interim, this should allow us to bump up to 0.7.2 and still provide the existing `auto_refresh` support folks had been using to avoid having to refresh access tokens themselves in long running processes.