### PR TITLE
fix: oauthlib conflicts with django2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     include_package_data=True,
     platforms="any",
     install_requires=[
-        "requests>=2.21.0", "oauthlib==2.1.0", "requests-oauthlib==1.0.0",
+        "requests>=2.21.0", "oauthlib>=2.1.0", "requests-oauthlib==1.0.0",
     ],
     test_suite='nose.collector',
     tests_require=["nose==1.3.7"],


### PR DESCRIPTION
Fix conflicts with `django-oauth-toolkit` which requires `oauthlib>3.0` for `Django2.2`, `pokitdok-python` requires `oauthlib==2.1.0`